### PR TITLE
ねこ未選択時のねこ部屋画面の動作を変更

### DIFF
--- a/PokerByTDD/ViewControllers/NekoRoomView.storyboard
+++ b/PokerByTDD/ViewControllers/NekoRoomView.storyboard
@@ -47,7 +47,7 @@
                                 <rect key="frame" x="137.5" y="291" width="100" height="100"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G2s-xW-hy9">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G2s-xW-hy9" customClass="CustomView" customModule="Design">
                                 <rect key="frame" x="67" y="269" width="240" height="128"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ねこを選んでいません" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eHy-KB-Fnw">
@@ -83,6 +83,7 @@
                     <connections>
                         <outlet property="nekoImage" destination="oUv-zX-toX" id="eC2-Ua-Qq7"/>
                         <outlet property="notSelectedNekoView" destination="G2s-xW-hy9" id="l4s-cB-Whi"/>
+                        <outlet property="selectButton" destination="AUS-eZ-Wrb" id="MhA-T6-ovL"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zcL-wy-aMd" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/PokerByTDD/ViewControllers/NekoRoomView.storyboard
+++ b/PokerByTDD/ViewControllers/NekoRoomView.storyboard
@@ -47,13 +47,42 @@
                                 <rect key="frame" x="137.5" y="291" width="100" height="100"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G2s-xW-hy9">
+                                <rect key="frame" x="67" y="269" width="240" height="128"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ねこを選んでいません" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eHy-KB-Fnw">
+                                        <rect key="frame" x="99" y="53" width="174" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AUS-eZ-Wrb" customClass="CommonDesignButton" customModule="Design">
+                                        <rect key="frame" x="99" y="78" width="31" height="30"/>
+                                        <state key="normal" title="選ぶ"/>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="128" id="Gbx-PS-mry"/>
+                                    <constraint firstItem="eHy-KB-Fnw" firstAttribute="top" secondItem="G2s-xW-hy9" secondAttribute="top" constant="40" id="R3y-sw-YvS"/>
+                                    <constraint firstItem="AUS-eZ-Wrb" firstAttribute="top" secondItem="eHy-KB-Fnw" secondAttribute="bottom" constant="10" id="SMU-r1-iMV"/>
+                                    <constraint firstItem="eHy-KB-Fnw" firstAttribute="centerX" secondItem="G2s-xW-hy9" secondAttribute="centerX" id="nFV-x7-DFB"/>
+                                    <constraint firstItem="AUS-eZ-Wrb" firstAttribute="centerX" secondItem="G2s-xW-hy9" secondAttribute="centerX" id="vs5-6X-Ehs"/>
+                                    <constraint firstAttribute="width" constant="240" id="xdk-eC-5ky"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" name="beige"/>
+                        <constraints>
+                            <constraint firstItem="G2s-xW-hy9" firstAttribute="centerX" secondItem="Bhc-Sh-fnj" secondAttribute="centerX" id="L37-fd-Ekq"/>
+                            <constraint firstItem="G2s-xW-hy9" firstAttribute="centerY" secondItem="Bhc-Sh-fnj" secondAttribute="centerY" id="oI0-Ne-Bjf"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Bhc-Sh-fnj"/>
                     </view>
                     <navigationItem key="navigationItem" title="ねこ部屋" id="JxO-Ir-cZE"/>
                     <connections>
                         <outlet property="nekoImage" destination="oUv-zX-toX" id="eC2-Ua-Qq7"/>
+                        <outlet property="notSelectedNekoView" destination="G2s-xW-hy9" id="l4s-cB-Whi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zcL-wy-aMd" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/PokerByTDD/ViewControllers/NekoRoomViewController.swift
+++ b/PokerByTDD/ViewControllers/NekoRoomViewController.swift
@@ -40,6 +40,7 @@ final class NekoRoomViewController: UIViewController, ColorSetViewProtocol {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        selectedNeko = Neko.selectedNeko()
         nekoImage.action(.sit)
     }
     

--- a/PokerByTDD/ViewControllers/NekoRoomViewController.swift
+++ b/PokerByTDD/ViewControllers/NekoRoomViewController.swift
@@ -15,10 +15,14 @@ import Utility
 final class NekoRoomViewController: UIViewController, ColorSetViewProtocol {
     
     @IBOutlet private weak var nekoImage: NekoAnimateView!
+    @IBOutlet private weak var notSelectedNekoView: UIView!
     
     private var selectedNeko: Neko? {
         didSet {
             selectedNeko.map(nekoImage.set)
+            let isSelectedNeko = (selectedNeko != .unknown && selectedNeko != nil)
+            notSelectedNekoView.isHidden = isSelectedNeko
+            nekoImage.isHidden = !isSelectedNeko
         }
     }
     

--- a/PokerByTDD/ViewControllers/NekoRoomViewController.swift
+++ b/PokerByTDD/ViewControllers/NekoRoomViewController.swift
@@ -15,7 +15,8 @@ import Utility
 final class NekoRoomViewController: UIViewController, ColorSetViewProtocol {
     
     @IBOutlet private weak var nekoImage: NekoAnimateView!
-    @IBOutlet private weak var notSelectedNekoView: UIView!
+    @IBOutlet private weak var notSelectedNekoView: CustomView!
+    @IBOutlet private weak var selectButton: CommonDesignButton!
     
     private var selectedNeko: Neko? {
         didSet {
@@ -50,6 +51,8 @@ final class NekoRoomViewController: UIViewController, ColorSetViewProtocol {
     
     func reloadColor(colorSet: ColorSet) {
         commonSetupColor(colorSet: colorSet)
+        notSelectedNekoView.reloadColor(colorSet: colorSet)
+        selectButton.colorSet = colorSet
     }
     
     @objc private func tapNeko(_ sender: UITapGestureRecognizer) {

--- a/PokerByTDD/ViewControllers/NekoRoomViewController.swift
+++ b/PokerByTDD/ViewControllers/NekoRoomViewController.swift
@@ -16,6 +16,12 @@ final class NekoRoomViewController: UIViewController, ColorSetViewProtocol {
     
     @IBOutlet private weak var nekoImage: NekoAnimateView!
     
+    private var selectedNeko: Neko? {
+        didSet {
+            selectedNeko.map(nekoImage.set)
+        }
+    }
+    
     private let bag = DisposeBag()
     
     private var nekoWalkDisposable: Disposable?
@@ -34,7 +40,6 @@ final class NekoRoomViewController: UIViewController, ColorSetViewProtocol {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        Neko.selectedNeko().map(nekoImage.set)
         nekoImage.action(.sit)
     }
     

--- a/PokerByTDD/ViewControllers/NekoRoomViewController.swift
+++ b/PokerByTDD/ViewControllers/NekoRoomViewController.swift
@@ -48,10 +48,14 @@ final class NekoRoomViewController: UIViewController, ColorSetViewProtocol {
     }
     
     @objc private func tapNeko(_ sender: UITapGestureRecognizer) {
+        // ねこを選択していない場合はタップ無効
+        guard let selectedNeko = selectedNeko, selectedNeko != .unknown else { return }
         nekoImage.action(.meow)
     }
     
     @objc private func longPressNeko(_ sender: UILongPressGestureRecognizer) {
+        // ねこを選択していない場合はロングタップ無効
+        guard let selectedNeko = selectedNeko, selectedNeko != .unknown else { return }
         if sender.state == .began {
             nekoImage.action(.frolic)
         }
@@ -61,6 +65,9 @@ final class NekoRoomViewController: UIViewController, ColorSetViewProtocol {
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        // ねこを選択していない場合はタップでの移動無効
+        guard let selectedNeko = selectedNeko, selectedNeko != .unknown else { return }
+        
         guard event?.touches(for: nekoImage) == nil else { return }
         
         guard let goalPoint = event?.allTouches?.first?.location(in: self.view) else { return }


### PR DESCRIPTION
ねこを表示しない
諸々のタップ動作を無効
未選択時に表示するビューを作成

選ぶボタンのタップでねこガチャ画面へ遷移させる処理を追加予定